### PR TITLE
Core: implemented NavigationViewHandler for Gtk

### DIFF
--- a/src/Controls/src/Core/NavigationPage.cs
+++ b/src/Controls/src/Core/NavigationPage.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Maui.Controls
 
 		partial void Init();
 
-#if WINDOWS || ANDROID || TIZEN
+#if WINDOWS || ANDROID || TIZEN || GTK
 		const bool UseMauiHandler = true;
 #else
 		const bool UseMauiHandler = false;

--- a/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
+++ b/src/Controls/src/Xaml/Hosting/AppHostBuilderExtensions.cs
@@ -135,7 +135,7 @@ namespace Microsoft.Maui.Controls.Hosting
 			handlersCollection.AddHandler<ShellSection, ShellSectionHandler>();
 #endif
 #endif
-#if WINDOWS || ANDROID || TIZEN
+#if WINDOWS || ANDROID || TIZEN || GTK
 			handlersCollection.AddHandler<NavigationPage, NavigationViewHandler>();
 			handlersCollection.AddHandler<Toolbar, ToolbarHandler>();
 			handlersCollection.AddHandler<FlyoutPage, FlyoutViewHandler>();

--- a/src/Core/src/Handlers/NavigationPage/NavigationViewHandler.Gtk.cs
+++ b/src/Core/src/Handlers/NavigationPage/NavigationViewHandler.Gtk.cs
@@ -13,28 +13,28 @@ namespace Microsoft.Maui.Handlers
 
 		protected override NavigationView CreatePlatformView()
 		{
-			return new();
+			return new NavigationView();
 		}
 
 		protected override void ConnectHandler(NavigationView nativeView)
 		{
 			base.ConnectHandler(nativeView);
-
-			var virtualView = VirtualView;
-
+			nativeView.Connect(VirtualView);
 		}
 
 		protected override void DisconnectHandler(NavigationView nativeView)
 		{
 			base.DisconnectHandler(nativeView);
-
-			var virtualView = VirtualView;
-
+			nativeView.Disconnect(VirtualView);
 		}
 
-		public static void RequestNavigation(INavigationViewHandler arg1, IStackNavigation arg2, object? arg3)
+		public static void RequestNavigation(INavigationViewHandler handler, IStackNavigation navigation, object? request)
 		{
-			throw new NotImplementedException();
+			if (handler is NavigationViewHandler platformHandler && request is NavigationRequest navRequest)
+			{
+				platformHandler.PlatformView?.RequestNavigation(navRequest);
+				navigation.NavigationFinished(navRequest.NavigationStack);
+			}
 		}
 	}
 

--- a/src/Core/src/Platform/Gtk/NavigationView.cs
+++ b/src/Core/src/Platform/Gtk/NavigationView.cs
@@ -1,10 +1,43 @@
+using System;
+using System.Linq;
+using Gtk;
+
 namespace Microsoft.Maui.Platform
 {
 
 	public class NavigationView : Gtk.Box
 	{
-
+		Gtk.Widget? pageWidget = null;
+		IMauiContext? mauiContext = null;
+		
 		public NavigationView() : base(Gtk.Orientation.Horizontal, 0) { }
+
+		public void Connect(IStackNavigationView virtualView)
+		{
+			mauiContext = virtualView.Handler?.MauiContext;
+		}
+
+		public void Disconnect(IStackNavigationView virtualView)
+		{
+		}
+
+		public void RequestNavigation(NavigationRequest request)
+		{
+			// stack top is last
+			var page = request.NavigationStack.Last();
+			var newPageWidget = page.ToPlatform(mauiContext!);
+			if (pageWidget is null)
+			{
+				this.PackStart(newPageWidget, true, true, 0);
+			}
+			else
+			{
+				this.Remove(pageWidget);
+				this.Add(newPageWidget);
+				this.SetChildPacking(newPageWidget, true, true, 0, PackType.Start);
+			}
+			pageWidget = newPageWidget;
+		}
 
 	}
 


### PR DESCRIPTION
Implemented NavigationViewHandler for Gtk.
Made changes so that NavigationViewHandler is used for NavigationPage in Gtk, instead of generic Page handler. It is incomplete at the moment. Processing of navigation events works, but toolbar is not implemented.