### PR TITLE
Remove maui path CI

### DIFF
--- a/.github/workflows/build-gtk.yml
+++ b/.github/workflows/build-gtk.yml
@@ -11,8 +11,6 @@ jobs:
     steps:
       - name: Checkout MAUI repo
         uses: actions/checkout@v2
-        with:
-          path: maui
       # We also tested using 6.0.111 for both projects
       # but MAUI failed to build on this version with this error:
       # Could not load file or assembly 'Microsoft.CodeAnalysis, Version=4.2.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35'
@@ -35,11 +33,8 @@ jobs:
             dotnet workload install gtk
       - name: Build MAUI
         run: |
-            cd maui
-            dotnet nuget add source --username ${{ github.repository_owner }} --password ${{ secrets.GITHUB_TOKEN }} --store-password-in-clear-text --name github "https://nuget.pkg.github.com/GtkSharp/index.json"
             dotnet build Microsoft.Maui.BuildTasks.slnf
             dotnet build ./src/Controls/samples/Controls.Sample.Gtk/Controls.Sample.Gtk.csproj
-            cd ..
 
   dotnet-format:
     needs: build_and_test


### PR DESCRIPTION
Previously we checked out maui into a path since we used GtkSharp by checking it out and directly building it. But since we now are using GtkSharp pre-built packages, we can discard having a separate folder for maui too, as we are not having a separate folder for GtkSharp.
