### PR TITLE
Fix Gtk workload install auto manifest update

### DIFF
--- a/.github/workflows/build-gtk.yml
+++ b/.github/workflows/build-gtk.yml
@@ -33,7 +33,7 @@ jobs:
             chmod 764 $WORKLOAD_MANIFEST_DIR/*
 
             dotnet workload search
-            dotnet workload install gtk
+            dotnet workload install gtk --skip-manifest-update
       - name: Build MAUI
         run: |
             dotnet build Microsoft.Maui.Gtk.slnf


### PR DESCRIPTION
Used --skip-manifest-update to avoid unwanted errors when GtkSharp has new manifest versions