### PR TITLE
Gtk: use vertical/horizontal options in layouts

### DIFF
--- a/src/Core/src/Platform/Gtk/LayoutView.cs
+++ b/src/Core/src/Platform/Gtk/LayoutView.cs
@@ -7,6 +7,7 @@ using System.Diagnostics;
 using System.Linq;
 using Gtk;
 using Microsoft.Maui.Graphics.Platform.Gtk;
+using Microsoft.Maui.Primitives;
 using Rectangle = Microsoft.Maui.Graphics.Rect;
 using Size = Microsoft.Maui.Graphics.Size;
 using Point = Microsoft.Maui.Graphics.Point;
@@ -232,6 +233,25 @@ namespace Microsoft.Maui.Platform
 
 				if (RestrictToMesuredAllocation)
 					mAllocation.Size = mesuredAllocation;
+
+				// Adjust for VerticalOptions
+				if (VirtualView.VerticalLayoutAlignment == LayoutAlignment.Center)
+				{
+					mAllocation.Top += (allocation.Height - mesuredAllocation.Height) / 2.0;
+				}
+				else if (VirtualView.VerticalLayoutAlignment == LayoutAlignment.End)
+				{
+					mAllocation.Top += (allocation.Height - mesuredAllocation.Height);
+				}
+				// Adjust for HorizontalOptions
+				if (VirtualView.HorizontalLayoutAlignment == LayoutAlignment.Center)
+				{
+					mAllocation.Left += (allocation.Width - mesuredAllocation.Width) / 2.0;
+				}
+				else if (VirtualView.VerticalLayoutAlignment == LayoutAlignment.End)
+				{
+					mAllocation.Left += (allocation.Width - mesuredAllocation.Width);
+				}
 
 				ArrangeAllocation(new Rectangle(Point.Zero, mAllocation.Size));
 				AllocateChildren(mAllocation);


### PR DESCRIPTION
Take VerticalOptions and HorizontalOptions of the layout into account when calculating layout on Gtk.
This allows to customize placement of root element of the page. Before the root layout would behave as if both options were set to "Start".