### PR TITLE
Sample.Gtk: add SourceGen as ProjectReference

### DIFF
--- a/src/Controls/samples/Controls.Sample.Gtk/Controls.Sample.Gtk.csproj
+++ b/src/Controls/samples/Controls.Sample.Gtk/Controls.Sample.Gtk.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.5" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\Controls\src\SourceGen\Controls.SourceGen.csproj" />
     <ProjectReference Include="..\..\..\Compatibility\Core\src\Compatibility.csproj" />
     <ProjectReference Include="..\..\..\Core\src\Core.csproj" />
     <ProjectReference Include="..\..\src\Core\Controls.Core.csproj" />


### PR DESCRIPTION
Added this to ensure that SourceGen.dll is created before building the Controls.Sample.Gtk. Below was the error:

```
CSC : error CS0006: Metadata file '/home/runner/work/maui/maui/.nuspec/Microsoft.Maui.Controls.SourceGen.dll' could not be found [/home/runner/work/maui/maui/src/Controls/samples/Controls.Sample.Gtk/Controls.Sample.Gtk.csproj]
    0 Warning(s)
    1 Error(s)
```


### Description of Change

<!-- Enter description of the fix in this section -->

### Issues Fixed

<!-- Please make sure that there is a bug logged for the issue being fixed. The bug should describe the problem and how to reproduce it. -->

Fixes #

<!--
Are you targeting the right branch?

- net6.0
  - This PR should be part of a .NET 6 service release.
- main (start here if you don't know what to use)
  - This PR should wait until .NET 7 is released.
- net7.0
  - This PR is very specific to .NET 7 SDK updates and wouldn't compile if they were to target main.
-->
